### PR TITLE
Error

### DIFF
--- a/ESP32/ESP32.ino
+++ b/ESP32/ESP32.ino
@@ -12,7 +12,9 @@
 #include "bluetooth.h"
 #include "main.h"
 #pragma GCC diagnostic pop
+#define LED_BUILTIN 2
 const bool DEBUG_MODE = false;
+
 
 void resetAll()
 {


### PR DESCRIPTION
exit status 1
'LED_BUILTIN' was not declared in this scope

source: https://techoverflow.net/2021/09/27/how-to-fix-esp32-platformio-error-led_builtin-was-not-declared-in-this-scope/